### PR TITLE
TiSpark Master端口号错误修复

### DIFF
--- a/website/book-rush/6-best-practice/2-tispark-practice/1-tispark.md
+++ b/website/book-rush/6-best-practice/2-tispark-practice/1-tispark.md
@@ -409,7 +409,7 @@ tiup cluster display cluster111
 
 ```shell
 # 手动启动 tispark节点
-tiup cluster start cluster111 -N 10.0.2.15:707,10.0.2.15:7078
+tiup cluster start cluster111 -N 10.0.2.15:7077,10.0.2.15:7078
 ```
 
 ## 五、测试


### PR DESCRIPTION
TiSpark Master节点端口错误由707修正为7077。
 tiup cluster start cluster111 -N 10.0.2.15:7077,10.0.2.15:7078